### PR TITLE
addressed default param for Fs - open issue in matplotlib - 9100

### DIFF
--- a/utils/spectogramer.py
+++ b/utils/spectogramer.py
@@ -20,7 +20,7 @@ def wav_to_spectrogram(audio_path, save_path, spectrogram_dimensions=(64, 64), n
 
     sample_rate, samples = wav.read(audio_path)
 
-    plt.specgram(samples, cmap=cmap, noverlap=noverlap)
+    plt.specgram(samples, cmap=cmap, Fs=2, noverlap=noverlap)
     plt.axis('off')
     plt.tight_layout()
     plt.savefig(save_path, bbox_inches="tight", pad_inches=0)


### PR DESCRIPTION

There's an issue in matplotlib which results in an error when running (the very helpful) spectrogramer.py.  It's addressed by manually passing what should be the default (Fs=2) to the plot function.

https://github.com/matplotlib/matplotlib/issues/9100