### PR TITLE
Make all country codes alpha-3 codes

### DIFF
--- a/metadata.py
+++ b/metadata.py
@@ -8,7 +8,7 @@ metadata = {
     },
     'nicolas': {
     	'gender': 'male',
-    	'accent': 'BE/French',
+    	'accent': 'BEL/French',
     	'language': 'english'
     },
     'theo': {


### PR DESCRIPTION
Make the used country codes homogenous.
As we are using three letter codes for USA and DEU, I changed the two letter code of BE to BEL.

See: [List_of_ISO_3166_country_codes](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)