### PR TITLE
Save spectrograms as desired without post-processing and python3 compatibility

### DIFF
--- a/acquire_data/say_numbers_prompt.py
+++ b/acquire_data/say_numbers_prompt.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import time
 import math
 
 """
-Prompts you to say numbers. 
+Prompts you to say numbers.
 
-Start this, and then hit "Record" in Audacity. 
+Start this, and then hit "Record" in Audacity.
 http://www.audacityteam.org/download/
 When you start Audacity, look in the bottom-left and set the Project Rate (Hz) to 8000.
 
@@ -15,7 +16,7 @@ Tips:
 - Try a short recording session first to make sure everything works OK before doing the full recording.
 
 
-When done, export the audio as one big .wav file and use 'split_and_label_numbers.py' 
+When done, export the audio as one big .wav file and use 'split_and_label_numbers.py'
 to make the labeled dataset.
 """
 
@@ -43,22 +44,22 @@ def generate_number_sequence():
 def show_numbers():
     nums = generate_number_sequence()
 
-    print "Get ready..."
+    print("Get ready...")
     time.sleep(1)
 
     t_start = time.time()
     for i, num in enumerate(nums):
         if (float(i)/len(nums) * 100) % 10 == 0:
-            print "\n====", float(i)/len(nums)*100, "% done====\n"
+            print("\n====", float(i)/len(nums)*100, "% done====\n")
         else:
-            print ""
+            print("")
 
         t_next_display = t_start + (i + 1) * DELAY_BETWEEN_NUMBERS
         t_next_blank = t_next_display + 2.5
 
         # display a number
         wait_until(t_next_display)
-        print num
+        print(num)
 
         # blank
         wait_until(t_next_blank)

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -6,5 +6,4 @@ python-dateutil==2.5.3
 pytz==2016.4
 scipy==0.17.1
 six==1.10.0
-Wand==0.4.3
 wheel==0.24.0

--- a/utils/fsdd.py
+++ b/utils/fsdd.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 from collections import defaultdict
 import scipy.io.wavfile
@@ -47,7 +48,7 @@ class FSDD:
 
         if data_dir is None:
             data_dir = os.path.dirname(__file__) + '/../spectrograms'
-            print data_dir
+            print(data_dir)
 
         file_paths = [f for f in os.listdir(data_dir) if os.path.isfile(os.path.join(data_dir, f)) and '.png' in f]
 

--- a/utils/spectogramer.py
+++ b/utils/spectogramer.py
@@ -7,7 +7,7 @@ from matplotlib import pyplot as plt
 import scipy.io.wavfile as wav
 
 
-def wav_to_spectrogram(audio_path, save_path, spectrogram_dimensions=(64, 64), noverlap=16, cmap='grey_r'):
+def wav_to_spectrogram(audio_path, save_path, spectrogram_dimensions=(64, 64), noverlap=16, cmap='gray_r'):
     """ Creates a spectrogram of a wav file.
 
     :param audio_path: path of wav file

--- a/utils/spectogramer.py
+++ b/utils/spectogramer.py
@@ -20,17 +20,18 @@ def wav_to_spectrogram(audio_path, save_path, spectrogram_dimensions=(64, 64), n
 
     sample_rate, samples = wav.read(audio_path)
 
-    plt.specgram(samples, cmap=cmap, Fs=2, noverlap=noverlap)
-    plt.axis('off')
-    plt.tight_layout()
-    plt.savefig(save_path, bbox_inches="tight", pad_inches=0)
-    plt.tight_layout()
+    fig, ax = plt.suplots()
+    ax.specgram(samples, cmap=cmap, Fs=2, noverlap=noverlap)
+    ax.set_axis_off()
+    ax.xaxis.set_major_locator(plt.NullLocator())
+    ax.yaxis.set_major_locator(plt.NullLocator())
+    fig.savefig(save_path, bbox_inches="tight", pad_inches=0)
 
     # TODO: Because I cant figure out how to create a plot without padding
     # I am using `.trim()`, It would be better to do this in the plot itself.
     # Also probably better to do the sizing in the plot too.
     with Image(filename=save_path) as i:
-        i.trim()
+        #i.trim()
         i.resize(spectrogram_dimensions[0], spectrogram_dimensions[1])
         i.save(filename=save_path)
 

--- a/utils/spectogramer.py
+++ b/utils/spectogramer.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, print_function
 from os import listdir
 from os.path import isfile, join
 from wand.image import Image
@@ -48,7 +48,7 @@ def dir_to_spectrogram(audio_dir, spectrogram_dir, spectrogram_dimensions=(64, 6
     file_names = [f for f in listdir(audio_dir) if isfile(join(audio_dir, f)) and '.wav' in f]
 
     for file_name in file_names:
-        print file_name
+        print(file_name)
         audio_path = audio_dir + file_name
         spectogram_path = spectrogram_dir + file_name.replace('.wav', '.png')
         wav_to_spectrogram(audio_path, spectogram_path, spectrogram_dimensions=spectrogram_dimensions, noverlap=noverlap, cmap=cmap)

--- a/utils/spectogramer.py
+++ b/utils/spectogramer.py
@@ -1,7 +1,6 @@
 from __future__ import division, print_function
 from os import listdir
 from os.path import isfile, join
-from wand.image import Image
 
 from matplotlib import pyplot as plt
 import scipy.io.wavfile as wav
@@ -20,20 +19,15 @@ def wav_to_spectrogram(audio_path, save_path, spectrogram_dimensions=(64, 64), n
 
     sample_rate, samples = wav.read(audio_path)
 
-    fig, ax = plt.suplots()
-    ax.specgram(samples, cmap=cmap, Fs=2, noverlap=noverlap)
+    fig = plt.figure()
+    fig.set_size_inches((spectrogram_dimensions[0]/fig.get_dpi(), spectrogram_dimensions[1]/fig.get_dpi()))
+    ax = plt.Axes(fig, [0., 0., 1., 1.])
     ax.set_axis_off()
+    fig.add_axes(ax)
+    ax.specgram(samples, cmap=cmap, Fs=2, noverlap=noverlap)
     ax.xaxis.set_major_locator(plt.NullLocator())
     ax.yaxis.set_major_locator(plt.NullLocator())
     fig.savefig(save_path, bbox_inches="tight", pad_inches=0)
-
-    # TODO: Because I cant figure out how to create a plot without padding
-    # I am using `.trim()`, It would be better to do this in the plot itself.
-    # Also probably better to do the sizing in the plot too.
-    with Image(filename=save_path) as i:
-        #i.trim()
-        i.resize(spectrogram_dimensions[0], spectrogram_dimensions[1])
-        i.save(filename=save_path)
 
 
 def dir_to_spectrogram(audio_dir, spectrogram_dir, spectrogram_dimensions=(64, 64), noverlap=16, cmap='gray_r'):


### PR DESCRIPTION
Dear @Jakobovski,
I tried to use this dataset (awesome idea and work by the way) with python 3 and had some trouble with the printing calls. I imported the print_function from the future module to keep it python 2 compatible.
I also saw the todo comment in the spectrogram script and changed the plot command accordingly to create figures without padding and resizing as desired.
During testing I fixed a spelling mistake with the colormap that triggers a ValueError with matplotlib.
If you like it and think it is useful I would be happy if you merge the changes :)

Best regards,
Felix