### PR TITLE
spectogramer.py: Move __future__ import to top of file

### DIFF
--- a/utils/spectogramer.py
+++ b/utils/spectogramer.py
@@ -1,5 +1,5 @@
-import os
 from __future__ import division, print_function
+import os
 from os import listdir
 from os.path import isfile, join
 


### PR DESCRIPTION
Running the script fails with:
```python
  File "spectogramer.py", line 2
    from __future__ import division, print_function
    ^
SyntaxError: from __future__ imports must occur at the beginning of the file
```